### PR TITLE
Move code into the +safemap package

### DIFF
--- a/Mcode/+safemap/safeMap.m
+++ b/Mcode/+safemap/safeMap.m
@@ -1,5 +1,7 @@
 function varargout = safeMap(function_handle, inputs, config)
-%%safeMap stores on disk partial results freeing memory and avoiding data loss
+%safeMap stores on disk partial results freeing memory and avoiding data loss
+%
+% varargout = safemap.safeMap(function_handle, inputs, config)
 %
 % The passed one parameter function is fed with each input cell and the outputs
 % are saved in a file as they are generated; a cell matrix containing the outputs,

--- a/Mcode/+safemap/safeMap_tests.m
+++ b/Mcode/+safemap/safeMap_tests.m
@@ -1,3 +1,7 @@
+% Tests for safeMap
+%
+% To run this, call safemap.safeMap_tests.
+
 % test triangles
 
 % inputs
@@ -15,7 +19,7 @@ delete progress.safemap.mat
 delete 1.mat
 expSize_ = size(vector_scalar_inputs);
 config_ = struct('filePath', '1.mat');
-output_file = safeMap(@(x) 1, vector_scalar_inputs, config_);
+output_file = safemap.safeMap(@(x) 1, vector_scalar_inputs, config_);
 sz_ = size(output_file, 'data');
 assert(isequal(sz_, expSize_), 'Output size wrong: obtained [%s] expected [%s]', num2str(sz_), num2str(expSize_));
 
@@ -24,7 +28,7 @@ delete 2.mat
 expSize_ = size(vector_scalar_inputs);
 expChildSize_ = [1 1];
 config_ = struct('joinUniformOutput', false, 'filePath', '2.mat');
-output_file = safeMap(@(x) 1, vector_scalar_inputs, config_);
+output_file = safemap.safeMap(@(x) 1, vector_scalar_inputs, config_);
 child_ = output_file.data(1, 1);
 sz_ = size(output_file, 'data'); 
 szc_ = size(child_{1}); 
@@ -35,7 +39,7 @@ assert(isequal(szc_, expChildSize_), 'Output cell size wrong: obtained [%s] expe
 delete 3.mat
 expSize_ = size(dim3_scalar_inputs);
 config_ = struct('joinUniformOutput', false, 'filePath', '3.mat');
-output_file = safeMap(@(x) 1, dim3_scalar_inputs, config_);
+output_file = safemap.safeMap(@(x) 1, dim3_scalar_inputs, config_);
 sz_ = size(output_file, 'data');
 assert(isequal(sz_, expSize_), 'Output size wrong: obtained [%s] expected [%s]', num2str(sz_), num2str(expSize_));
 
@@ -43,7 +47,7 @@ assert(isequal(sz_, expSize_), 'Output size wrong: obtained [%s] expected [%s]',
 delete 4.mat
 expSize_ = [size(dim3_scalar_inputs) 10 10 2];
 config_ = struct('filePath', '4.mat');
-output_file = safeMap(@(x) repmat(magic(10), 1, 1, 2), dim3_scalar_inputs, config_);
+output_file = safemap.safeMap(@(x) repmat(magic(10), 1, 1, 2), dim3_scalar_inputs, config_);
 sz_ = size(output_file, 'data');
 assert(isequal(sz_, expSize_), 'Output size wrong: obtained [%s] expected [%s]', num2str(sz_), num2str(expSize_));
 
@@ -52,7 +56,7 @@ delete 5.mat
 expSize_ = size(dim3_scalar_inputs);
 expChildSize_ = [10 10 2];
 config_ = struct('joinUniformOutput', false, 'filePath', '5.mat');
-output_file = safeMap(@(x) repmat(magic(10), 1, 1, 2), dim3_scalar_inputs, config_);
+output_file = safemap.safeMap(@(x) repmat(magic(10), 1, 1, 2), dim3_scalar_inputs, config_);
 child_ = output_file.data(1,1,1);
 sz_ = size(output_file, 'data');
 szc_ = size(child_{1});
@@ -63,7 +67,7 @@ assert(isequal(szc_, expChildSize_), 'Output cell size wrong: obtained [%s] expe
 delete 6.mat
 expSize_ = size(vector_vector_inputs);
 config_ = struct('returnData', true, 'filePath', '6.mat');
-[maxValues, maxIndexs] = safeMap(@max, vector_vector_inputs, config_);
+[maxValues, maxIndexs] = safemap.safeMap(@max, vector_vector_inputs, config_);
 sz1_ = size(maxValues);
 sz2_ = size(maxIndexs);
 assert(isequal(sz1_, expSize_) && isequal(sz2_, expSize_), 'Output sizes wrong: obtained [%s] and [%s], expected [%s]', num2str(sz1_), num2str(sz2_), num2str(expSize_));
@@ -72,7 +76,7 @@ assert(isequal(sz1_, expSize_) && isequal(sz2_, expSize_), 'Output sizes wrong: 
 delete 7.mat
 expSize_ = [length(vector_vector_inputs) 5];
 config_ = struct('variableName', {{'values', 'indexs'}}, 'filePath', '7.mat');
-output_file = safeMap(@(x) maxk(x, 5), vector_vector_inputs, config_);
+output_file = safemap.safeMap(@(x) maxk(x, 5), vector_vector_inputs, config_);
 sz1_ = size(output_file, 'values');
 sz2_ = size(output_file, 'indexs');
 assert(allInFile(output_file, {'values', 'indexs'}), 'Variables not found in output file');
@@ -83,7 +87,7 @@ delete 8.mat
 expSize_ = size(vector_vector_inputs);
 expChildSize_ = [1 5];
 config_ = struct('returnData', true, 'joinUniformOutput', false, 'filePath', '8.mat');
-maxValues = safeMap(@(x) maxk(x, 5), vector_vector_inputs, config_);
+maxValues = safemap.safeMap(@(x) maxk(x, 5), vector_vector_inputs, config_);
 sz_ = size(maxValues);
 szc_ = size(maxValues{1});
 assert(isequal(sz_, expSize_), 'Output size wrong: obtained [%s] expected [%s]', num2str(sz_), num2str(expSize_));
@@ -95,9 +99,9 @@ config_ = struct('filePath', '9.mat');
 data = true(size(vector_scalar_inputs));
 data(50) = false;
 try
-    output_file = safeMap(@(i) data(i) || {}, vector_scalar_inputs, config_);
+    output_file = safemap.safeMap(@(i) data(i) || {}, vector_scalar_inputs, config_);
 catch
-    output_file = safeMap(@(i) false, vector_scalar_inputs, config_);
+    output_file = safemap.safeMap(@(i) false, vector_scalar_inputs, config_);
 end
 assert(isequal(output_file.data(1:49), true(1, 49)), '');
 assert(isequal(output_file.data(50:end), false(1, length(vector_scalar_inputs)-49)), '');

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Memory and interruption safe map <!-- omit in toc -->
+
 ### Alternative for Matlab® `cellfun` <!-- omit in toc -->
 
 [![View safeMap on File Exchange](https://www.mathworks.com/matlabcentral/images/matlab-file-exchange.svg)](https://it.mathworks.com/matlabcentral/fileexchange/90807-safemap)
@@ -13,11 +14,11 @@ Moreover, the used file paths and the name under which each output variable is s
 <!--When needed, the number of outputs can be manually specified (`config.numberOfFunctionOutputs`) otherwise it will be inferred.-->
 
 ```matlab
->> output = safeMap(@(x) rand(1,300)*x^5*rand(300,1), repmat({rand(300)}, 100, 100));
+>> output = safemap.safeMap(@(x) rand(1,300)*x^5*rand(300,1), repmat({rand(300)}, 100, 100));
 Progress: 731 / 10000 (7.3%)
 Estimated remaining time: 143s
 🔴(Ctrl+C) Operation terminated by user during ...
->> output = safeMap(@(x) rand(1,300)*x^5*rand(300,1), repmat({rand(300)}, 100, 100));
+>> output = safemap.safeMap(@(x) rand(1,300)*x^5*rand(300,1), repmat({rand(300)}, 100, 100));
 Resuming previous work, from 732-th input
 Progress: 10000 / 10000 (100.0%)
 Estimated remaining time: 0s
@@ -38,19 +39,17 @@ Estimated remaining time: 0s
 - [Contributing](#contributing)
 - [License](#license)
 
-
 ## Installation
 
-Download the [function](https://raw.githubusercontent.com/ferrarodav/safeMap/main/safeMap.m) and put it in your workspace.
+Clone the [repo](https://raw.githubusercontent.com/ferrarodav/safeMap) (or [download a copy of the latest code](https://github.com/ferrarodav/safeMap/archive/refs/heads/main.zip)) and add the `Mcode` directory to your MATLAB path with `addpath`.
 
-Or clone the whole repository with git:
 ```bash
-git clone https://github.com/ferrarodav/safeMap.git
+git clone https://github.com/ferrarodav/safeMap
 ```
 
 ## Arguments
 
-`safeMap(function_handle, inputs, config)`
+`safemap.safeMap(function_handle, inputs, config)`
 - `function_handle`: a function handle (@nameOfYourFunction or @(x) expression)
 - `inputs`: indicates the `function_handle` inputs, can be a cell array, a
     matrix or a scalar (`n` means `1:n`)
@@ -86,8 +85,8 @@ all_params = cell(1, length(hps));
 
 % trick to pass multiple inputs since it is currently not supported by safeMap
 ins = cellfun(@(a,b,c,d) {a, b, c, d}, all_params{:}, 'un', 0);
-output_file = safeMap(@(vars) data * vars{1} * vars{2} * vars{3}, ins);
-% desiderable: safeMap(@(a,b,c,d) a * b * c, all_params{:});
+output_file = safemap.safeMap(@(vars) data * vars{1} * vars{2} * vars{3}, ins);
+% desiderable: safemap.safeMap(@(a,b,c,d) a * b * c, all_params{:});
 
 % read the output corresponding to hps: 1, 4, 100
 disp(output_file.data(1,4,3,1)); % 400
@@ -106,14 +105,14 @@ ans =
 >> size(data{1}) 
 ans =
     1      1000    
->> maxValues, maxIndexs = safeMap(@(x) maxk(x, 2), data, struct('returnData', true));
+>> maxValues, maxIndexs = safemap.safeMap(@(x) maxk(x, 2), data, struct('returnData', true));
 >> size(maxValues) 
 ans =
     100    2
 >> size(maxIndexs) 
 ans =
     100    2
->> output_file = safeMap(@(x) maxk(x, 2), data, struct('variableNames', 'filePath', 'max.mat', {{'values', 'indexs'}}));
+>> output_file = safemap.safeMap(@(x) maxk(x, 2), data, struct('variableNames', 'filePath', 'max.mat', {{'values', 'indexs'}}));
 >> who -file max.mat
 
 Your variables are:


### PR DESCRIPTION
What do you think about sticking this code in a Matlab package (AKA "namespace")? I know you've only got the one function right now (plus the test script), but this seems like a significant enough tool that it might grow other functions (or even classes) in time. Sticking it in a package makes it play nice with other Matlab libraries, because it only takes up the one top-level "`safemap`" identifier, instead of one identifier for every function you have.